### PR TITLE
Fix: Correct CSS selector for 'Show More' button

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,7 +665,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             font-weight: bold;
         }
 
-        .expandable-content.expanded .see-more-btn {
+        .expandable-content.expanded + .see-more-btn {
             display: none;
         }
 


### PR DESCRIPTION
The 'Show More' button for the product description was not being hidden when the description was expanded. This was due to an incorrect CSS selector that was trying to target the button as a descendant of the expandable content area, when it is actually a sibling.

This commit corrects the CSS selector from a descendant selector (` `) to an adjacent sibling selector (`+`) to properly target and hide the 'Show More' button when the content is expanded.